### PR TITLE
Fix summary text for beta 2

### DIFF
--- a/MessagesExtension/MessagesViewController.swift
+++ b/MessagesExtension/MessagesViewController.swift
@@ -120,7 +120,7 @@ class MessagesViewController: MSMessagesAppViewController, MessagesViewDelegate 
             guard let conversation = activeConversation else { fatalError("Expected a conversation") }
             let session = conversation.selectedMessage?.session ?? MSSession()
             guard let message = newPair.composeMessage(session) else { fatalError("Expected a message") }
-            let changeDescription = state.changeDescription() // TODO: Removed in beta2. Why?
+            message.summaryText = state.changeDescription()
             conversation.insert(message) { error in
                 if let error = error {
                     fatalError("Message could not be inserted into conversation: \(error)") // TODO: investigate when this happens


### PR DESCRIPTION
In beta 2 the documentation and API "header" files show different methods to add a MSMessage to the current MSConversation. I don't know how it was in beta 1, but now summaryText is a property of MSMessage. This property is used in this fix.
